### PR TITLE
Look for __res_query if res_query is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ PKG_CHECK_MODULES([check], [check >= 0.9.4], [],
 AC_CHECK_LIB(pthread, pthread_create, [],
     [AC_MSG_ERROR([pthread support is required])])
 AC_CHECK_LIB(resolv, res_query, [],
-    [AC_MSG_ERROR([libresolv is not found])])
+    [AC_CHECK_LIB(resolv, __res_query, [], [AC_MSG_ERROR([libresolv is not found])])])
 
 if test "x$with_libxml2" = xyes; then
     PKG_CHECK_MODULES([libxml2], [libxml-2.0 >= 2.7], [],


### PR DESCRIPTION
Hi pasis,

I hope you'll accept my pull requests, as libstrophe looks quite dead to me. I'm going to push some out to you in the next few minutes. Here is the first, which fixes building for me on Fedora 16. 

Seems like current libresolv has a layer of indirection here. 

regards,
Jonas
