### PR TITLE
Fix two memory leaks

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -553,6 +553,7 @@ static void _auth(xmpp_conn_t * const conn)
 	    disconnect_mem_error(conn);
 	    return;
 	}
+	xmpp_free(conn->ctx, authid);
 	xmpp_stanza_set_text(authdata, str);
 	xmpp_free(conn->ctx, str);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -282,6 +282,8 @@ int xmpp_conn_release(xmpp_conn_t * const conn)
 		xmpp_free(ctx, conn->stream_id);
 	if (conn->lang)
 		xmpp_free(ctx, conn->lang);
+	if (conn->tls)
+		tls_free(conn->tls);
 	xmpp_free(ctx, conn);
 
 	return 1;


### PR DESCRIPTION
(1) the connection did not release its TLS context in
    xmpp_conn_release.
(2) in auth.c:_auth, authid wasn't freed

Note: this patch is ported from libstrophe and I might've been wrong when rebasing, please peer-review before merge.
