### PR TITLE
Publish abstracted XML parser API

### DIFF
--- a/couplet.h
+++ b/couplet.h
@@ -389,6 +389,27 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long  timeout);
 void xmpp_run(xmpp_ctx_t *ctx);
 void xmpp_stop(xmpp_ctx_t *ctx);
 
+/** XML parser abstraction */
+
+typedef void (*parser_start_callback)(char *name,
+                                      char **attrs,
+                                      void * const userdata);
+typedef void (*parser_end_callback)(char *name, void * const userdata);
+typedef void (*parser_stanza_callback)(xmpp_stanza_t *stanza,
+                                       void * const userdata);
+
+typedef struct _parser_t parser_t;
+
+parser_t *parser_new(xmpp_ctx_t *ctx,
+                     parser_start_callback startcb,
+                     parser_end_callback endcb,
+                     parser_stanza_callback stanzacb,
+                     void *userdata);
+void parser_free(parser_t * const parser);
+int parser_reset(parser_t *parser);
+int parser_feed(parser_t *parser, char *chunk, int len);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/parser.h
+++ b/src/parser.h
@@ -21,23 +21,4 @@
 
 #include "couplet.h"
 
-typedef struct _parser_t parser_t;
-
-typedef void (*parser_start_callback)(char *name,
-                                      char **attrs,
-                                      void * const userdata);
-typedef void (*parser_end_callback)(char *name, void * const userdata);
-typedef void (*parser_stanza_callback)(xmpp_stanza_t *stanza,
-                                       void * const userdata);
-
-
-parser_t *parser_new(xmpp_ctx_t *ctx,
-                     parser_start_callback startcb,
-                     parser_end_callback endcb,
-                     parser_stanza_callback stanzacb,
-                     void *userdata);
-void parser_free(parser_t * const parser);
-int parser_reset(parser_t *parser);
-int parser_feed(parser_t *parser, char *chunk, int len);
-
 #endif /* __LIBSTROPHE_PARSER_H__ */


### PR DESCRIPTION
This publishes the parser_\* functions through couplet.h.

This is quite helpful, as one can use the parser for config files etc. and still being able to compile for both libxml2 and libexpat. It obviously imposes the restrictions which are implemented in the layer of abstraction, but for config files and similar, these are quite low.
