### PR TITLE
High CPU usage during idle

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -53,12 +53,13 @@
 #include "thread.h"
 #include "list.h"
 
+
 #ifndef DEFAULT_TIMEOUT
 /** @def DEFAULT_TIMEOUT
  *  The default timeout in milliseconds for the event loop.
  *  This is set to 1 millisecond.
  */
-#define DEFAULT_TIMEOUT 1
+#define DEFAULT_TIMEOUT 20
 #endif
 
 /** Run send loop once.


### PR DESCRIPTION
libcouplet has a quite high CPU usage during idle. While this can be fixed by increasing `DEFAULT_TIMEOUT` (50ms gives fine timings for timed handlers and an acceptable CPU usage), there should be other ways, regarding the fact that we have now threads. See #7 for a discussion of those.
