### PR TITLE
Fix crash on keys containing non-latin1 symbols

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -109,13 +109,13 @@ void hash_release(hash_t * const table)
 /** hash a key for our table lookup */
 static int _hash_key(hash_t *table, const char *key)
 {
-   int hash = 0;
+   unsigned int hash = 0;
    int shift = 0;
    const char *c = key;
 
    while (*c != '\0') {
 	/* assume 32 bit ints */
-	hash ^= ((int)*c++ << shift);
+	hash ^= ((unsigned int)*c++ << shift);
 	shift += 8;
 	if (shift > 24) shift = 0;
    }


### PR DESCRIPTION
Fix crash on key values with non-latin1 symbols due to negative hash value).
